### PR TITLE
Adding current editable file in comment

### DIFF
--- a/markmon.py
+++ b/markmon.py
@@ -98,7 +98,11 @@ class MarkmonClient:
          if self.settings.running and MARKDOWN_SYNTAX.match(view.scope_name(0)):
             try:
                 connection = http.client.HTTPConnection(self.settings.client_url)
-                connection.request('PUT', '/', view.substr(sublime.Region(0, view.size())).encode('utf-8'))
+                # connection.request('PUT', '/', view.substr(sublime.Region(0, view.size())).encode('utf-8'))
+                openedfile_path = sublime.active_window().active_view().file_name()
+                shebang_comment = u'<!--FILEPATH:[' + openedfile_path + u'];-->'
+                payload = b"".join([shebang_comment.encode('utf-8'), view.substr(sublime.Region(0, view.size())).encode('utf-8')])
+                connection.request('PUT', '/', payload)
                 connection.getresponse()
             except ConnectionRefusedError:
                 if self.server:


### PR DESCRIPTION
Hello! First of all, thank you for great plugin!
I need custom markdown preprocessing, so i've created a ruby script and connected it via `cmd` parameter. But, there is no options to send current editable filepath to this script (for example, i want generate base64 from images relative to editable filepath).
For my needs i've modified `view_updated` function for insert html comment string, containing filepath to markdown head.
